### PR TITLE
Add Matrix Link, Fix 404 Page, and Hide Blog Column

### DIFF
--- a/404.html
+++ b/404.html
@@ -50,30 +50,31 @@
 
 <body>
     <div id="header-wrapper">
-        <div id="header" class="row">
-            <div class="large-12 columns clearfix">
-                <h1 class="brackets-logo">
-                    <a href="index.html">
-                        <i></i>Brackets</a>
-                </h1>
-                <div class="mobile-nav">
-                    <a id="hamburger" href="#">Menu</a>
+    <div id="header" class="row">
+        <div class="large-11 columns clearfix">
+            <h1 class="brackets-logo">
+                <a href="index.html">
+                    <i></i>Brackets Continued</a>
+            </h1>
+            <div class="mobile-nav">
+                <a id="hamburger" href="#">Menu</a>
+            </div>
+            <div class="nav clearfix">
+                <div class="nav-links">
+                    <a href="contribute.html" class="contribute" data-i18n="nav.contribute">Contribute</a>
+                    <a href="docs/current/modules/brackets.html" data-i18n="nav.apidocs">API Docs</a>
+                    <!-- <a href="http://blog.brackets.io" data-i18n="nav.blog">Blog</a> -->
+                    <a href="https://registry.brackets.io" data-i18n="nav.extensions">Extensions</a>
+                    <a href="https://github.com/brackets-cont/brackets/wiki/Troubleshooting" data-i18n="nav.support">Support</a>
                 </div>
-                <div class="nav clearfix">
-                    <div class="nav-links">
-                        <a href="contribute.html" class="contribute" data-i18n="nav.contribute">Contribute</a>
-                        <a href="docs/current/modules/brackets.html" data-i18n="nav.apidocs">API Docs</a>
-                        <a href="http://blog.brackets.io" data-i18n="nav.blog">Blog</a>
-                        <a href="https://github.com/adobe/brackets/wiki/Troubleshooting" data-i18n="nav.support">Support</a>
-                    </div>
-                    <div class="social-links">
-                        <a class="social-links-item github-icon" href="https://www.github.com/adobe/brackets" title="GitHub">GitHub</a>
-                        <a class="social-links-item twitter-icon" href="https://twitter.com/brackets" title="Twitter">Twitter</a>
-                    </div>
+                <div class="social-links">
+                    <a class="social-links-item github-icon" href="https://www.github.com/brackets-cont/brackets" title="GitHub">GitHub</a>
+                    <!-- <a class="social-links-item twitter-icon" href="https://twitter.com/brackets" title="Twitter">Twitter</a>-->
                 </div>
             </div>
         </div>
     </div>
+</div>
     
     <div id="hero-wrapper" class="gradient">
         <div id="hero" class="row no-bg-img">

--- a/contribute.html
+++ b/contribute.html
@@ -238,7 +238,7 @@
                     <a href="https://plus.google.com/b/115365194873502050036/">Google+</a>
                 </li> -->
 				<li>
-					<a href="#">Matrix Server/Slack Channel (Coming Soon)</a>
+					<a href="https://matrix.to/#/%23brackets-cont:matrix.org">Matrix</a>
 				</li>
             </ul>
         </div>

--- a/index.html
+++ b/index.html
@@ -218,17 +218,17 @@
 
             <p><a class="button radius secondary" href="https://ingorichter.github.io/BracketsExtensionTweetBot/" data-i18n="index.page.content.popular-extensions.check-out">Check Out New Extensions</a></p>
         </div>
-        <div class="medium-4 large-4 columns">
+        <!-- <div class="medium-4 large-4 columns">
             <h2 data-i18n="index.page.content.blog.header">Recent Blog Posts</h2>
             <div class="spinner" id="blogposts-spinner">
             </div>
             <div id="blogposts">
-                <!-- this will be filled dynamically -->
+                <!-- this will be filled dynamically -/->
             </div>
             <p>
                 <a class="button radius secondary" href="data:text/plain,Coming Soon" data-i18n="index.page.content.blog.more">Go to Blog</a>
             </p>
-        </div>
+        </div> -->
     </div>
 </div>
 
@@ -311,7 +311,7 @@
                     <a href="https://plus.google.com/b/115365194873502050036/">Google+</a>
                 </li> -->
 				<li>
-					<a href="#">Matrix Server/Slack Channel (Coming Soon)</a>
+					<a href="https://matrix.to/#/%23brackets-cont:matrix.org">Matrix</a>
 				</li>
             </ul>
         </div>


### PR DESCRIPTION
The footer on the home and contribute pages now lists our new matrix room under Keep In Touch. I also updated the header on the 404 page to match the other pages. I also hid the blog column because we don't currently have a blog (On the current site, the column fails to load any posts)