### PR TITLE
Added discord, twitter links to navigation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,18 @@
             >
               GitHub
             </a>
+            <a
+              href="https://twitter.com/BracketsCont"
+              class="nav-link w-inline-block"
+            >
+              Twitter
+            </a>
+            <a
+              href="https://discord.com/invite/rBpTBPttca"
+              class="nav-link w-inline-block"
+            >
+              Discord
+            </a>
           </nav>
           <div class="navigation-link-right desktop-link">
             <a href="https://github.com/adobe/brackets/releases">


### PR DESCRIPTION
Contributions from friends @[Phoenix project](https://github.com/aicore/phoenix)

Added links directing to brackets twitter page and brackets discord community in the navigation bar

### A quick preview of added hyper links
![Screenshot from 2021-10-06 15-49-03](https://user-images.githubusercontent.com/48797926/136184940-b00ef0f8-9f68-4c6a-aadb-5856ceb1d1ed.png)

### Responsive view 
![Screenshot from 2021-10-06 15-52-05](https://user-images.githubusercontent.com/48797926/136185307-83761594-0e8f-4405-8e3d-9469e6e93434.png)

### Alternate design idea (nav)

Added icons instead of text

![Screenshot from 2021-10-06 16-22-01](https://user-images.githubusercontent.com/48797926/136189620-efd12369-282d-436d-b047-96dbad190201.png)


