### PR TITLE
Update download UX

### DIFF
--- a/404.html
+++ b/404.html
@@ -131,6 +131,15 @@
     </div>
 
     <script src="js/vendor/jquery.js"></script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XHYXL1VHXW"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-XHYXL1VHXW');
+    </script>
     <script src="/js/nav.js"></script>
   </body>
 </html>

--- a/contribute.html
+++ b/contribute.html
@@ -104,7 +104,7 @@
               Extensions
             </a>
             <a
-              href="https://github.com/brackets-cont/brackets/wiki/Troubleshooting"
+              href="https://github.com/brackets-cont/brackets/discussions"
               data-i18n="nav.support"
               class="nav-link w-inline-block"
             >
@@ -350,7 +350,7 @@
           </ul>
         </div>
         <div class="medium-6 large-3 columns">
-          <h5 id="contribute" data-i18n="footer.get-involved.header">
+          <h5 id="contribute-inv" data-i18n="footer.get-involved.header">
             Get Involved
           </h5>
           <ul>
@@ -544,23 +544,14 @@
       });
     </script>
 
-    <script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(["_setAccount", "UA-32881640-1"]);
-      _gaq.push(["_setDomainName", "brackets.io"]);
-      _gaq.push(["_gat._anonymizeIp"]);
-      _gaq.push(["_trackPageview"]);
-      (function () {
-        var ga = document.createElement("script");
-        ga.type = "text/javascript";
-        ga.async = true;
-        ga.src =
-          ("https:" == document.location.protocol
-            ? "https://ssl"
-            : "http://www") + ".google-analytics.com/ga.js";
-        var s = document.getElementsByTagName("script")[0];
-        s.parentNode.insertBefore(ga, s);
-      })();
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XHYXL1VHXW"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-XHYXL1VHXW');
     </script>
   </body>
 </html>

--- a/contribute.html
+++ b/contribute.html
@@ -31,6 +31,7 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <link rel="stylesheet" href="css/normalize.css" />
     <link rel="stylesheet" href="css/foundation.min.css" />
+    <link rel="stylesheet" href="fontawesome-free-5.15.4-web/css/all.css"/>
 
     <!-- social media images -->
     <link rel="image_src" href="/img/hero.png" />
@@ -72,63 +73,81 @@
     <link rel="alternate" href="?lang=pt-br" hreflang="pt-br" />
   </head>
   <body id="contribute">
-    <!-- Navigation Menu -->
-    <div class="navbar w-nav">
-      <div class="navbar-base">
-        <div class="navigation-container">
-          <div class="navigation-side">
-            <a href="/" class="brand w-nav-brand w--current">
-              <img src="./img/brackets.svg" alt="Brackets logo" class="logo" />
-            </a>
-          </div>
-          <nav class="nav-menu w-nav-menu" id="nav-menu">
+  <!-- Navigation Menu -->
+  <div class="navbar w-nav">
+    <div class="navbar-base">
+      <div class="navigation-container">
+        <div class="navigation-side">
+
+          <a href="/" class="brand w-nav-brand w--current">
+            <img src="./img/brackets.svg" alt="Brackets logo" class="logo" />
+          </a>
+        </div>
+        <div class="nav-left-menu" id="nav-l">
+
+          <div class="nav-menu w-nav-menu" id="nav-lmenu">
+            <!--  <nav class="nav-menu w-nav-menu" id="nav-menu">-->
             <a
-              href="contribute.html"
-              data-i18n="nav.contribute"
-              class="nav-link w-inline-block"
+                    href="contribute.html"
+                    data-i18n="nav.contribute"
+                    class="nav-link w-inline-block"
             >
               Contribute
             </a>
             <a
-              href="docs/current/modules/brackets.html"
-              data-i18n="nav.apidocs"
-              class="nav-link w-inline-block"
+                    href="docs/current/modules/brackets.html"
+                    data-i18n="nav.apidocs"
+                    class="nav-link w-inline-block"
             >
               API Docs
             </a>
             <a
-              href="https://registry.brackets.io"
-              data-i18n="nav.extensions"
-              class="nav-link w-inline-block"
+                    href="https://registry.brackets.io"
+                    data-i18n="nav.extensions"
+                    class="nav-link w-inline-block"
             >
               Extensions
             </a>
             <a
-              href="https://github.com/brackets-cont/brackets/discussions"
-              data-i18n="nav.support"
-              class="nav-link w-inline-block"
+                    href="https://github.com/brackets-cont/brackets/discussions"
+                    data-i18n="nav.support"
+                    class="nav-link w-inline-block"
             >
-              Suppport
+              Support
             </a>
-            <a
-              href="https://www.github.com/brackets-cont/brackets"
-              class="nav-link w-inline-block"
-            >
-              GitHub
-            </a>
-          </nav>
-          <div class="navigation-link-right desktop-link">
-            <a href="#">
-              <button class="download-button">Download</button>
-            </a>
-          </div>
-          <div class="hamburgerMenuIcon" id="hamburger">
-            <i class="bx bx-menu"></i>
           </div>
         </div>
+        <nav class="nav-right-menu" id="nav-r">
+          <div class="nav-menu w-nav-menu" id="nav-rmenu">
+            <a
+                    href="https://www.github.com/brackets-cont/brackets"
+                    class="nav-link w-inline-block"
+            >
+              <i class="fab fa-github"></i>
+            </a>
+            <a
+                    href="https://twitter.com/BracketsCont"
+                    class="nav-link w-inline-block"
+            >
+              <i class="fab fa-twitter"></i>
+            </a>
+            <a
+                    href="https://discord.com/invite/rBpTBPttca"
+                    class="nav-link w-inline-block"
+            >
+              <i class="fab fa-discord"></i>
+
+            </a>
+          </div>
+        </nav>
+        <div class="hamburgerMenuIcon" id="hamburger">
+          <i class="bx bx-menu"></i>
+        </div>
+
       </div>
     </div>
-    <!-- End of Navigation Menu -->
+  </div>
+  <!-- End of Navigation Menu -->
 
     <div id="hero-wrapper">
       <div id="hero" class="row">

--- a/index.html
+++ b/index.html
@@ -32,8 +32,10 @@
     </title>
     <script type="text/javascript">
       window.bracketsVersion = "1.14.2";
-      window.windowsBuildURL = "https://github.com/adobe/brackets/releases/download/release-1.14.2/Brackets.Release.1.14.2.msi";
-      window.macBuildURL = "https://github.com/adobe/brackets/releases/download/release-1.14.2/Brackets.Release.1.14.2.dmg";
+      window.buildURL = {
+        WIN: "https://github.com/adobe/brackets/releases/download/release-1.14.2/Brackets.Release.1.14.2.msi",
+        OSX: "https://github.com/adobe/brackets/releases/download/release-1.14.2/Brackets.Release.1.14.2.dmg"
+      };
     </script>
 
     <link rel="stylesheet" href="css/normalize.css" />
@@ -174,7 +176,17 @@
               </a>
             </div>
             <div class="navigation-link-right desktop-link">
-                <button class="download-button">Download</button>
+              <a id="download-nav-brackets"
+                 class="large rounded radius"
+                 href="https://github.com/adobe/brackets/releases"
+                 download>
+                <button data-i18n="[html]index.page.hero.download"
+                        class="download-button"
+                        onclick="navDownloadClicked()">
+                  <i class="fa fa-spinner fa-spin" style="visibility: hidden; margin-left: -16px" id="navDownloadSpinner"></i>
+                  Download </d>
+                </button>
+              </a>
             </div>
           </nav>
           <div class="hamburgerMenuIcon" id="hamburger">
@@ -232,9 +244,12 @@
             <!-- Temporary link to download page -->
             <a id="download-plain-brackets"
                class="large rounded radius"
-               href="https://github.com/adobe/brackets/releases">
+               href="https://github.com/adobe/brackets/releases"
+               download>
                 <button data-i18n="[html]index.page.hero.download"
-                        class="download-button">
+                        class="download-button"
+                        onclick="mainDownloadClicked()">
+                  <i class="fa fa-spinner fa-spin" style="visibility: hidden; margin-left: -16px" id="mainDownloadSpinner"></i>
                     Download v<d id="download-brackets-version">1.14.2</d>
               </button>
             </a>
@@ -626,39 +641,32 @@
       }
 
       function setupDownloads() {
-        console.log(OS);
+        let downloadURL = buildURL[OS] || "https://github.com/brackets-cont/brackets/releases";
+        document.getElementById("download-plain-brackets")
+                .setAttribute("href",downloadURL);
+        document.getElementById("download-nav-brackets")
+                .setAttribute("href",downloadURL);
+      }
+      function mainDownloadClicked() {
+        document.getElementById("mainDownloadSpinner")
+                .setAttribute("style", "margin-left: -16px")
+        setTimeout(()=>{
+          document.getElementById("mainDownloadSpinner")
+                  .setAttribute("style", "visibility:hidden; margin-left: -16px")
+        },20000); // We dont have an API to determine if browser actually started the download. So clear after 20 secs.
+      }
+
+      function navDownloadClicked() {
+        document.getElementById("navDownloadSpinner")
+                .setAttribute("style", "margin-left: -16px")
+        setTimeout(()=>{
+          document.getElementById("navDownloadSpinner")
+                  .setAttribute("style", "visibility:hidden; margin-left: -16px")
+        },20000);
       }
     </script>
 
     <script>
-
-          // update features (limit 5)
-          var feature_content =
-            "<h2>" +
-            i18n.t("index.page.content.new-features.new-features-in", {
-              defaultValue: "New in " + build.versionString,
-              sprintNumber: build.versionString,
-            }) +
-            "</h2>";
-          build.newFeatures
-            .slice(0, Math.min(build.newFeatures.length, 5))
-            .forEach(function (feature) {
-              feature_content +=
-                "<h3>" + $("<div/>").text(feature.name).html() + "</h3>";
-              feature_content +=
-                "<p>" + $("<div/>").text(feature.description).html() + "</p>";
-            });
-          feature_content +=
-            "<p><a class='button radius secondary' href='" +
-            build.releaseNotesURL +
-            "'>" +
-            i18n.t("index.page.content.new-features.release-notes", {
-              defaultValue: "Read More in the Release Notes",
-            }) +
-            "</a></p>";
-          $("#features").html(feature_content);
-        });
-      });
 
       function logAndGo(elementID, _url, tagObj) {
         var elem = document.getElementById(elementID);

--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@
     <title data-i18n="index.head.title">
       Brackets - A modern, open source code editor that understands web design.
     </title>
+    <script type="text/javascript">
+      window.bracketsVersion = "1.14.2";
+      window.windowsBuildURL = "https://github.com/adobe/brackets/releases/download/release-1.14.2/Brackets.Release.1.14.2.msi";
+      window.macBuildURL = "https://github.com/adobe/brackets/releases/download/release-1.14.2/Brackets.Release.1.14.2.dmg";
+    </script>
 
     <link rel="stylesheet" href="css/normalize.css" />
     <link rel="stylesheet" href="css/foundation.min.css" />
@@ -101,7 +106,7 @@
     <link rel="alternate" href="?lang=it" hreflang="it" />
     <link rel="alternate" href="?lang=pt-br" hreflang="pt-br" />
   </head>
-  <body id="home">
+  <body id="home" onload="setupDownloads()">
     <!-- Navigation Menu -->
     <div class="navbar w-nav">
       <div class="navbar-base">
@@ -169,9 +174,7 @@
               </a>
             </div>
             <div class="navigation-link-right desktop-link">
-              <a href="https://github.com/adobe/brackets/releases">
                 <button class="download-button">Download</button>
-              </a>
             </div>
           </nav>
           <div class="hamburgerMenuIcon" id="hamburger">
@@ -227,27 +230,22 @@
           </div>
           <div id="download">
             <!-- Temporary link to download page -->
-            <a
-              id="download-plain-brackets"
-              class="large rounded radius"
-              href="https://github.com/adobe/brackets/releases"
-            >
-              <button
-                data-i18n="[html]index.page.hero.download"
-                class="download-button"
-              >
-                Download v<d id="download-brackets-version">1.14.2</d>
+            <a id="download-plain-brackets"
+               class="large rounded radius"
+               href="https://github.com/adobe/brackets/releases">
+                <button data-i18n="[html]index.page.hero.download"
+                        class="download-button">
+                    Download v<d id="download-brackets-version">1.14.2</d>
               </button>
             </a>
             <div id="os-alert" class="alert-box radius" data-alert></div>
             <p>
-              <a
-                id="other-downloads"
+              <a id="other-downloads"
                 class="nobr"
                 href="https://github.com/brackets-cont/brackets/releases"
-                data-i18n="index.page.hero.other-downloads"
-                >Pre-release builds & Other Downloads</a
-              >
+                data-i18n="index.page.hero.other-downloads">
+                Pre-release builds & Other Downloads
+              </a>
             </p>
             <!--
                 This <img> tag will be added when NOT on mobile
@@ -356,89 +354,62 @@
 
     <div id="content-wrapper">
       <div id="content" class="row">
+        <h2 data-i18n="index.page.content.popular-extensions.header" >
+          Popular Extensions
+        </h2>
         <div class="medium-4 large-4 columns" id="features">
-          <h2 data-i18n="index.page.content.new-features.new-features">
-            New Features
-          </h2>
-          <div class="spinner"></div>
-
-          <!-- JS generated content -->
-        </div>
-        <div class="medium-4 large-4 columns">
-          <h2 data-i18n="index.page.content.popular-extensions.header">
-            Popular Extensions
-          </h2>
+          <h3><a href="https://github.com/zaggino/brackets-git">Git</a></h3>
+          <p data-i18n="index.page.content.popular-extensions.list.git">
+            Git integration for Brackets.
+          </p>
 
           <h3><a href="https://github.com/emmetio/brackets-emmet">Emmet</a></h3>
           <p data-i18n="index.page.content.popular-extensions.list.emmet">
             High-speed HTML and CSS workflow.
           </p>
 
-          <h3>
-            <a href="https://github.com/drewhamlett/brackets-beautify"
-              >Beautify</a
-            >
-          </h3>
+          <h3><a href="https://github.com/drewhamlett/brackets-beautify">Beautify</a></h3>
           <p data-i18n="index.page.content.popular-extensions.list.beautify">
             Format JavaScript, HTML, and CSS files.
           </p>
 
-          <h3>
-            <a href="https://github.com/ivogabe/Brackets-Icons">File Icons</a>
-          </h3>
-          <p
-            data-i18n="index.page.content.popular-extensions.list.ivogabe-icons"
-          >
+          <h3><a href="https://github.com/gruehle/MarkdownPreview">Markdown Preview</a></h3>
+          <p data-i18n="index.page.content.popular-extensions.list.markdown">
+            Live preview of markdown documents.
+          </p>
+
+        </div>
+        <div class="medium-4 large-4 columns">
+          <h3><a href="https://github.com/ivogabe/Brackets-Icons">File Icons</a></h3>
+          <p data-i18n="index.page.content.popular-extensions.list.ivogabe-icons">
             File icons in Brackets’ file tree.
           </p>
 
-          <h3>
-            <a href="https://github.com/lkcampbell/brackets-indent-guides"
-              >Indent Guides</a
-            >
-          </h3>
-          <p
-            data-i18n="index.page.content.popular-extensions.list.indent-guides"
-          >
+          <h3><a href="https://github.com/lkcampbell/brackets-indent-guides">Indent Guides</a></h3>
+          <p data-i18n="index.page.content.popular-extensions.list.indent-guides">
             Show indent guides in the code editor.
           </p>
 
-          <h3><a href="https://github.com/zaggino/brackets-git">Git</a></h3>
-          <p data-i18n="index.page.content.popular-extensions.list.git">
-            Git integration for Brackets.
-          </p>
-
-          <h3>
-            <a href="https://github.com/mikaeljorhult/brackets-autoprefixer"
-              >Autoprefixer</a
-            >
-          </h3>
-          <p
-            data-i18n="index.page.content.popular-extensions.list.autoprefixer"
-          >
+          <h3><a href="https://github.com/mikaeljorhult/brackets-autoprefixer">Autoprefixer</a></h3>
+          <p data-i18n="index.page.content.popular-extensions.list.autoprefixer">
             Parse CSS and add vendor prefixes automatically.
           </p>
 
-          <h3>
-            <a href="https://github.com/cfjedimaster/brackets-w3cvalidation"
-              >W3C Validation</a
-            >
-          </h3>
-          <p
-            data-i18n="index.page.content.popular-extensions.list.w3cvalidation"
-          >
+          <h3><a href="https://github.com/cfjedimaster/brackets-w3cvalidation">W3C Validation</a></h3>
+          <p data-i18n="index.page.content.popular-extensions.list.w3cvalidation">
             Simple W3C Validator.
           </p>
 
           <p>
             <a
               class="button radius secondary"
-              href="https://ingorichter.github.io/BracketsExtensionTweetBot/"
+              href="https://registry.brackets.io/"
               data-i18n="index.page.content.popular-extensions.check-out"
               >Check Out New Extensions</a
             >
           </p>
         </div>
+
         <!-- <div class="medium-4 large-4 columns">
             <h2 data-i18n="index.page.content.blog.header">Recent Blog Posts</h2>
             <div class="spinner" id="blogposts-spinner">
@@ -622,9 +593,20 @@
       if (/Windows|Win32|WOW64|Win64/.test(navigator.userAgent)) {
         OS = "WIN";
         ext = ".msi";
+        if (/NT ?5\.\d/.test(navigator.userAgent)) {
+          FLAVOR = "Windows XP";
+        }
       } else if (/Mac/.test(navigator.userAgent)) {
         OS = "OSX";
         ext = ".dmg";
+        osMatch = navigator.userAgent.match(/Mac OS X 10[._](\d+)([._](\d+))?\D/i)
+        osMatch = parseFloat(osMatch[1] + "." + (osMatch[3] || 0));
+
+        // Firefox reports only the OS X major version (10.6), so we have to check for 6.0
+        if (osMatch < 6.8 && osMatch !== 6.0) {
+          // Mac OS X pre 10.6.8 is not supported
+          FLAVOR = "Mac OS X 10." + osMatch;
+        }
       } else if (/Linux|X11/.test(navigator.userAgent)) {
         OS = "LINUX32";
         ext = ".32-bit.deb";
@@ -642,231 +624,13 @@
           "<img src='img/hero.png' srcset='img/hero@2x.png 2x' height='370' width='1059' alt='Screenshot of Brackets'>"
         ).appendTo("#download");
       }
+
+      function setupDownloads() {
+        console.log(OS);
+      }
     </script>
 
     <script>
-      // Detect unsupported Operating Systems
-      function updateAlertContent(unsupported) {
-        var translatedText = i18n.t(
-          "index.page.hero.os-alert." + unsupported.i18nKey,
-          {
-            os: unsupported.os,
-            defaultValue: unsupported.default,
-            url: unsupported.url,
-          }
-        );
-        $("#os-alert").html(translatedText).show();
-      }
-
-      var osMatch,
-        unsupported = {
-          i18nKey: "general",
-          url: "https://github.com/brackets-cont/brackets/wiki/Troubleshooting#requirements",
-        };
-
-      // Windows XP
-      if (/NT ?5\.\d/.test(navigator.userAgent)) {
-        unsupported.os = "Windows XP";
-        unsupported.i18nKey = "win-xp";
-        unsupported.url =
-          "http://blog.brackets.io/2014/04/18/windows-xp-support/";
-        unsupported.default =
-          "Unfortunately, we don't support Windows XP any longer. <a href='" +
-          unsupported.url +
-          "'>Read our blog post</a> for further information.";
-
-        // Mac OS X 10.*
-      } else if (
-        (osMatch = navigator.userAgent.match(
-          /Mac OS X 10[._](\d+)([._](\d+))?\D/i
-        ))
-      ) {
-        osMatch = parseFloat(osMatch[1] + "." + (osMatch[3] || 0));
-
-        // Firefox reports only the OS X major version (10.6), so we have to check for 6.0
-        if (osMatch < 6.8 && osMatch !== 6.0) {
-          // Mac OS X pre 10.6.8 is not supported
-          unsupported.os = "Mac OS X 10." + osMatch;
-        }
-
-        // Debian 7
-      } else if (/Debian[ -_]7/i.test(navigator.userAgent)) {
-        unsupported.os = "Debian 7";
-        unsupported.i18nKey = "debian-7";
-        unsupported.url =
-          "https://github.com/brackets-cont/brackets/issues/4816";
-        unsupported.default =
-          "Unfortunately, we currently don't support Debian 7. <a href='" +
-          unsupported.url +
-          "'>Take a look at the GitHub issue</a> for further information.";
-
-        // Ubuntu
-      } else if (
-        (osMatch = navigator.userAgent.match(/Ubuntu[ -_\/]?(\d+)[._](\d+)\D/i))
-      ) {
-        // Pre-Ubuntu 12.04
-        if (parseInt(osMatch[1], 10) < 12) {
-          unsupported.os = "Ubuntu " + osMatch[1] + "." + osMatch[2];
-        }
-      }
-
-      // The user is running an unsupported OS
-      if (unsupported.os) {
-        if (!unsupported.default) {
-          unsupported.default =
-            "Unfortunately, we don't support " +
-            unsupported.os +
-            " any longer. <a href='" +
-            unsupported.url +
-            "'>Take a look at the Requirements.</a>";
-        }
-        $("#hero-cta-button").hide();
-        $("#download-plain-brackets").hide();
-        updateAlertContent(unsupported);
-        if (!i18nLoaded.state() !== "resolved") {
-          i18nLoaded.done(function () {
-            updateAlertContent(unsupported);
-          });
-        }
-      }
-
-      i18nLoaded.done(function () {
-        // load the complete license string
-        var licenseStr = i18n.t("footer.project-info.license", {
-          defaultValue: "Brackets is released under the MIT License",
-        });
-        // load the license type string
-        var licenseTypeStr = i18n.t("footer.project-info.licensetype", {
-          defaultValue: "MIT License",
-        });
-        // identify the license type string and wrap it in an anchor
-        licenseStr = licenseStr.replace(
-          licenseTypeStr,
-          "<a href='https://github.com/brackets-cont/brackets/blob/master/LICENSE'>" +
-            licenseTypeStr +
-            "</a>"
-        );
-        $("#about div p").append(licenseStr + ".");
-      });
-
-      var shortLocale =
-          (requestedLang && requestedLang.split("/")[0].split("-")[0]) || "en",
-        versionInfoBaseUrl =
-          "http://files.brackets.s3.us-east-2.amazonaws.com/updates/stable/",
-        versionInfoUrl = versionInfoBaseUrl + shortLocale + ".json",
-        lookupPromise = new $.Deferred();
-
-      if (shortLocale !== "en") {
-        $.ajax({
-          url: versionInfoUrl,
-          type: "HEAD",
-        })
-          .fail(function () {
-            shortLocale = "en";
-            versionInfoUrl = versionInfoBaseUrl + shortLocale + ".json";
-          })
-          .always(function () {
-            lookupPromise.resolve();
-          });
-      } else {
-        lookupPromise.resolve();
-      }
-
-      lookupPromise.done(function () {
-        var ajaxRequest = $.ajax({
-          dataType: "json",
-          url: versionInfoUrl,
-          cache: false,
-        });
-
-        $.when(ajaxRequest, i18nLoaded).done(function (data) {
-          var allBuilds = data[0],
-            build = data[0][0]; // default initialization with latest build
-
-          // Find the applicable build for current platform
-          // If current platform is unsupported (OTHERS), then take the last common release
-          // If a build entry doesn't have 'platforms' key -> Older format for all supported OS
-          for (
-            var buildIndex = 0;
-            buildIndex < allBuilds.length;
-            buildIndex++
-          ) {
-            build = allBuilds[buildIndex];
-            if (!build.platforms) {
-              // Older format detected - Applicable to all platforms
-              break;
-            } else {
-              if (build.platforms[OS]) {
-                // Current platform is one of the supported platforms
-                break;
-              } else if (OS == "OTHER") {
-                // Unsupported platform detected
-                if (Object.keys(build.platforms).length == 4) {
-                  // Build applicable for all platforms
-                  break;
-                }
-              }
-            }
-          }
-
-          var buildName = build.versionString;
-
-          // Probe previous entry to see if the update is a dot update,
-          // in which case combine both the entries.
-          var prevBuild = data[0][1];
-          if (
-            prevBuild &&
-            prevBuild.versionString &&
-            prevBuild.versionString === buildName
-          ) {
-            build.newFeatures = prevBuild.newFeatures.concat(build.newFeatures);
-          }
-
-          if (buildName) {
-            var buildNum = buildName.match(/([\d.]+)/);
-            if (buildNum) {
-              buildNum = buildNum[1];
-            }
-
-            // update button
-            if (OS !== "OTHER" && buildNum) {
-              var url;
-              if (build.platforms && build.platforms[OS]) {
-                // Fetch download url from platform entry
-                url = build.platforms[OS].downloadURL;
-              } else {
-                // Generate the download URI
-                var tag = buildName.toLowerCase().split(" ").join("-");
-                url =
-                  "https://github.com/brackets-cont/brackets/releases/" + tag;
-
-                if (ext) {
-                  url =
-                    "https://github.com/brackets-cont/brackets/releases/download/" +
-                    tag +
-                    "/Brackets." +
-                    buildName.split(" ").join(".") +
-                    ext;
-                }
-              }
-
-              $("#download-brackets-version").text(buildNum);
-              logAndGo("download-plain-brackets", url, [
-                "_trackEvent",
-                "Downloads",
-                buildNum,
-                OS,
-              ]);
-            }
-
-            // other-download track
-            logAndGo("other-downloads", $("#other-downloads").attr("href"), [
-              "_trackEvent",
-              "Other-Downloads",
-              buildNum,
-              OS,
-            ]);
-          }
 
           // update features (limit 5)
           var feature_content =
@@ -913,61 +677,6 @@
           });
         };
       }
-    </script>
-
-    <script>
-      function recentBlogposts() {
-        var dateRegex = /(\d+)-(\d+)-(\d+)\s+(\d+):(\d+):(\d+)/,
-          $blogposts = $("#blogposts");
-
-        $.ajax({
-          url: "http://blog.brackets.io/feed/json",
-          dataType: "jsonp",
-        })
-          .always(function () {
-            $("#blogposts-spinner").remove();
-            $blogposts.hide();
-            $blogposts.fadeIn(1000);
-          })
-          .done(function (data) {
-            var options = {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            };
-
-            data.slice(0, 8).forEach(function (item) {
-              // only ever display 8 blog posts
-              var dateComponents = item.date.match(dateRegex),
-                postingDate = new Date(
-                  dateComponents[1],
-                  dateComponents[2] - 1, // zero based month
-                  dateComponents[3],
-                  dateComponents[4],
-                  dateComponents[5],
-                  dateComponents[6]
-                );
-
-              $blogposts.append(
-                '<h3><a href="' +
-                  item.permalink +
-                  '">' +
-                  item.title +
-                  "</a></h3><p>" +
-                  postingDate.toLocaleDateString(requestedLang, options) +
-                  "</p>"
-              );
-            });
-          })
-          .fail(function () {
-            var errorString = i18n.t("index.page.content.blog.error", {
-              defaultValue: "Refresh page to load posts",
-            });
-            $blogposts.append("<p>" + errorString + "</p>");
-          });
-      }
-
-      $(recentBlogposts());
     </script>
 
     <script type="text/javascript">

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
                 Extensions
               </a>
               <a
-                href="https://github.com/brackets-cont/brackets/wiki/Troubleshooting"
+                href="https://github.com/brackets-cont/brackets/discussions"
                 data-i18n="nav.support"
                 class="nav-link w-inline-block"
               >

--- a/index.html
+++ b/index.html
@@ -646,8 +646,11 @@
                 .setAttribute("href",downloadURL);
         document.getElementById("download-nav-brackets")
                 .setAttribute("href",downloadURL);
+        document.getElementById("other-downloads")
+                .addEventListener('click',otherDownloadClicked);
       }
       function mainDownloadClicked() {
+        logDownloadClicked("main");
         document.getElementById("mainDownloadSpinner")
                 .setAttribute("style", "margin-left: -16px")
         setTimeout(()=>{
@@ -657,6 +660,7 @@
       }
 
       function navDownloadClicked() {
+        logDownloadClicked("navBar");
         document.getElementById("navDownloadSpinner")
                 .setAttribute("style", "margin-left: -16px")
         setTimeout(()=>{
@@ -664,47 +668,33 @@
                   .setAttribute("style", "visibility:hidden; margin-left: -16px")
         },20000);
       }
+
+      function otherDownloadClicked() {
+        logDownloadClicked("otherDownloads");
+      }
     </script>
 
     <script>
 
-      function logAndGo(elementID, _url, tagObj) {
-        var elem = document.getElementById(elementID);
-        elem.href = _url;
-        elem.onclick = function (e) {
-          e.preventDefault();
-          var downloadStarted = false;
-          setTimeout(function () {
-            if (!downloadStarted) window.location.href = _url;
-          }, 1200); // fallback
-          _gaq.push(tagObj, function () {
-            downloadStarted = true;
-            setTimeout(function () {
-              window.location.href = _url;
-            }, 1000); // short delay just in case it doesn't get logged
+      function logDownloadClicked(whichButton) {
+        gtag('event', whichButton, {
+          'event_category': "download",
+          'event_label': "clicked",
+          'value': 1
           });
-        };
       }
     </script>
 
-    <script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(["_setAccount", "UA-32881640-1"]);
-      _gaq.push(["_setDomainName", "brackets.io"]);
-      _gaq.push(["_gat._anonymizeIp"]);
-      _gaq.push(["_trackPageview"]);
-      (function () {
-        var ga = document.createElement("script");
-        ga.type = "text/javascript";
-        ga.async = true;
-        ga.src =
-          ("https:" == document.location.protocol
-            ? "https://ssl"
-            : "http://www") + ".google-analytics.com/ga.js";
-        var s = document.getElementsByTagName("script")[0];
-        s.parentNode.insertBefore(ga, s);
-      })();
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XHYXL1VHXW"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-XHYXL1VHXW');
     </script>
+
     <script>
       var closeButton = document.getElementById("banner-close-button");
       var banner = document.getElementById("banner-wrapper");


### PR DESCRIPTION
- Update download UX to auto-download based on os without redirecting to GitHub releases.
- Remove unused code for os detection notifications. Minor reformatting.
- Move to brackets google analytics from Adobe analytics.

## UI changes
* Start downloading spinner appears when you click on download 
  ![image](https://user-images.githubusercontent.com/5336369/142360716-af07cf14-c24f-4db4-abb1-1796e36ae31b.png)
* Top banner of contribute page updated to reuse navbar of main page
  ![image](https://user-images.githubusercontent.com/5336369/142361100-9bbf8a0e-eee7-4d62-ac55-b5c58a0cc369.png)


