### PR TITLE
Fix minor download button issue

### DIFF
--- a/css/brackets.io.css
+++ b/css/brackets.io.css
@@ -536,6 +536,7 @@ blockquote p {
   background-color: #010001;
   font-weight: 600;
   border-radius: 5px;
+  min-width: 150px;
 }
 
 .download-button:hover {


### PR DESCRIPTION
This fixes an issue with the download button looking wrong on certain screens. When I sized my browser window to be one half of my 1920 x 1200 screen, the button is too tall..
![image](https://user-images.githubusercontent.com/30136040/169346252-60bb0020-164e-411b-b335-c352d1b60471.png)

This is being caused by the spinner moving to the next line when the button gets too narrow:
![image](https://user-images.githubusercontent.com/30136040/169346767-4eee9edb-7cda-47a7-9589-cd1c9ea05e2f.png)

I fixed this by adding a minimum width of 150px but it might be better to change the width at which the mobile view is used
